### PR TITLE
fix: remove target requirement for zap approvals

### DIFF
--- a/configuration/chains/1/conditions.json
+++ b/configuration/chains/1/conditions.json
@@ -14,10 +14,7 @@
     "implementationId": "IMPLEMENTATION_YEARN_VAULTS",
     "methodName": "approve",
     "paramTypes": ["address", "uint256"],
-    "requirements": [
-      ["target", "isVaultUnderlyingToken"],
-      ["param", "isZapInContract", "0"]
-    ]
+    "requirements": [["param", "isZapInContract", "0"]]
   },
   {
     "id": "VAULT_DEPOST",


### PR DESCRIPTION
`isVaultUnderlyingToken` check for the target token is not necessary here since a zapper input tokens are not restricted to yearn underlying vault tokens